### PR TITLE
TA-3_Additional_Added a new package with example for synchronized non-access modifier

### DIFF
--- a/src/main/java/com/iulifinttraining/accessmodifiers/synchronizednonaccessmodifier/SynchronizedJavaDemonstration.java
+++ b/src/main/java/com/iulifinttraining/accessmodifiers/synchronizednonaccessmodifier/SynchronizedJavaDemonstration.java
@@ -1,0 +1,53 @@
+package com.iulifinttraining.accessmodifiers.synchronizednonaccessmodifier;
+
+public class SynchronizedJavaDemonstration {
+
+    public static void main(String[] args) {
+        final Table table = new Table();
+        Thread thread1 = new Thread(() -> {
+            System.out.println("Thread1 is running");
+            table.printEverything(5);
+            System.out.println("Thread1 finished");
+        });
+
+        Thread thread2 = new Thread(() -> {
+            System.out.println("Thread2 is running");
+            table.printEverything(10);
+            System.out.println("Thread2 is finished");
+        });
+        Thread3 thread3 = new Thread3(table);
+        Thread4 thread4 = new Thread4(table);
+        // Next I have started all threads, but as well I have added join() methods in order to wait for a thread to finish
+        // its work and after that start another one. If join () method will be removed, then threads might be executed asynchronously
+        // but, it will be no more that just one thread at a time to use the printEverything method from Table class.
+        thread1.start();
+        try {
+            thread1.join();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+
+        }
+        thread2.start();
+        try {
+            thread2.join();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+
+        }
+        thread3.start();
+        try {
+            thread3.join();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+
+        }
+        thread4.start();
+        try {
+            thread4.join();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+
+    }
+}

--- a/src/main/java/com/iulifinttraining/accessmodifiers/synchronizednonaccessmodifier/Table.java
+++ b/src/main/java/com/iulifinttraining/accessmodifiers/synchronizednonaccessmodifier/Table.java
@@ -1,0 +1,15 @@
+package com.iulifinttraining.accessmodifiers.synchronizednonaccessmodifier;
+
+public class Table {
+
+    public synchronized void printEverything(int n){
+        for (int i = 1; i <= n; i++) {
+            System.out.println(i*n);
+            try {
+                Thread.sleep(400L);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/com/iulifinttraining/accessmodifiers/synchronizednonaccessmodifier/Thread3.java
+++ b/src/main/java/com/iulifinttraining/accessmodifiers/synchronizednonaccessmodifier/Thread3.java
@@ -1,0 +1,13 @@
+package com.iulifinttraining.accessmodifiers.synchronizednonaccessmodifier;
+
+public class Thread3 extends Thread{
+    Table t;
+    public Thread3(Table t){
+        this.t = t;
+    }
+    public void run() {
+        System.out.println("Thread3 is running");
+        t.printEverything(5);
+        System.out.println("Thread3 is finished");
+    }
+}

--- a/src/main/java/com/iulifinttraining/accessmodifiers/synchronizednonaccessmodifier/Thread4.java
+++ b/src/main/java/com/iulifinttraining/accessmodifiers/synchronizednonaccessmodifier/Thread4.java
@@ -1,0 +1,13 @@
+package com.iulifinttraining.accessmodifiers.synchronizednonaccessmodifier;
+
+public class Thread4 extends Thread{
+    Table t;
+    public Thread4(Table t){
+        this.t = t;
+    }
+    public void run() {
+        System.out.println("Thread4 is running");
+        t.printEverything(10);
+        System.out.println("Thread4 is finished");
+    }
+}


### PR DESCRIPTION
As part of this pull request, I have created a java class SynchronizedJavaDemonstration in which I have created one final object of the class Table from the newly added package: **synchronizednonaccessmodifier**, as well added two threads which will execute one synchronized method from the Table class. As well have two additional classes Thread3 and Thread4 in order to present two ways of creating java threads, created objects for them and started the thread's job.